### PR TITLE
Support advanced inspect metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_install:
     uidmap -y
   - git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
   - cd $GOPATH/src/github.com/containers/libpod
+  - which go
   - GO111MODULE=auto make BUILDTAGS="selinux seccomp varlink systemd"
   - sudo make install PREFIX=/usr
   - sudo mkdir -p /etc/containers

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
     bats
     btrfs-tools
     git
-    golang-go
     go-md2man
     iptables
     jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ before_install:
     uidmap -y
   - git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
   - cd $GOPATH/src/github.com/containers/libpod
-  - which go
-  - GO111MODULE=auto make BUILDTAGS="selinux seccomp varlink systemd"
+  - GO=$(which go) GO111MODULE=auto make BUILDTAGS="selinux seccomp varlink systemd"
   - sudo make install PREFIX=/usr
   - sudo mkdir -p /etc/containers
   - sudo curl https://raw.githubusercontent.com/containers/skopeo/master/default-policy.json -o /etc/containers/policy.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   - git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
   - cd $GOPATH/src/github.com/containers/libpod
   - make BUILDTAGS="selinux seccomp varlink systemd"
-  - sudo --preserve-env make install PREFIX=/usr
+  - sudo "PATH=$PATH" make install PREFIX=/usr
   - sudo mkdir -p /etc/containers
   - sudo curl https://raw.githubusercontent.com/containers/skopeo/master/default-policy.json -o /etc/containers/policy.json
   # Install podman runtime dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ before_install:
     uidmap -y
   - git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
   - cd $GOPATH/src/github.com/containers/libpod
-  - GO=$(which go) GO111MODULE=auto make BUILDTAGS="selinux seccomp varlink systemd"
-  - sudo make install PREFIX=/usr
+  - make BUILDTAGS="selinux seccomp varlink systemd"
+  - sudo --preserve-env make install PREFIX=/usr
   - sudo mkdir -p /etc/containers
   - sudo curl https://raw.githubusercontent.com/containers/skopeo/master/default-policy.json -o /etc/containers/policy.json
   # Install podman runtime dependencies

--- a/helpers.go
+++ b/helpers.go
@@ -14,8 +14,8 @@ import (
 var ErrNotImplemented = errors.New("dipod: not implemented")
 
 // WriteError returns an error response to the client.
-func WriteError(res http.ResponseWriter, err error) {
-	res.WriteHeader(http.StatusInternalServerError)
+func WriteError(res http.ResponseWriter, statusCode int, err error) {
+	res.WriteHeader(statusCode)
 	err = json.NewEncoder(res).Encode(
 		types.ErrorResponse{Message: ErrorMessage(err)},
 	)

--- a/images.go
+++ b/images.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/go-connections/nat"
 	"github.com/gorilla/mux"
 	"github.com/moby/moby/api/types"
 	log "github.com/sirupsen/logrus"
@@ -308,7 +309,33 @@ func ImageInspect(res http.ResponseWriter, req *http.Request) {
 	if workdir, ok := config["WorkingDir"]; ok {
 		image.Config.WorkingDir = workdir.(string)
 	}
-
+	if user, ok := config["User"]; ok {
+		image.Config.User = user.(string)
+	}
+	if stopSignal, ok := config["StopSignal"]; ok {
+		image.Config.StopSignal = stopSignal.(string)
+	}
+	if tmp, ok := config["ExposedPorts"]; ok {
+		image.Config.ExposedPorts = make(nat.PortSet)
+		ports := tmp.(map[string]interface{})
+		for port := range ports {
+			image.Config.ExposedPorts[nat.Port(port)] = struct{}{}
+		}
+	}
+	if tmp, ok := config["Volumes"]; ok {
+		image.Config.Volumes = make(map[string]struct{})
+		vols := tmp.(map[string]interface{})
+		for vol := range vols {
+			image.Config.Volumes[vol] = struct{}{}
+		}
+	}
+	if tmp, ok := config["Labels"]; ok {
+		image.Config.Labels = make(map[string]string)
+		labels := tmp.(map[string]interface{})
+		for key, val := range labels {
+			image.Config.Labels[key] = val.(string)
+		}
+	}
 	image.ContainerConfig = image.Config
 
 	// graph driver

--- a/images.go
+++ b/images.go
@@ -27,7 +27,7 @@ import (
 func ImageList(res http.ResponseWriter, req *http.Request) {
 	all := req.FormValue("all")
 	if all == "1" || all == "true" {
-		WriteError(res, ErrNotImplemented)
+		WriteError(res, http.StatusNotImplemented, ErrNotImplemented)
 		return
 	}
 	filters, err := filters.FromParam(req.FormValue("filters"))
@@ -253,8 +253,12 @@ func ImageInspect(res http.ResponseWriter, req *http.Request) {
 
 	// podman for some reason returns this as JSON string, need to decode
 	payload, err := iopodman.InspectImage().Call(podman, name)
+	if notFound, ok := err.(*iopodman.ImageNotFound); ok {
+		WriteError(res, http.StatusNotFound, errors.New(notFound.Reason))
+		return
+	}
 	if err != nil {
-		WriteError(res, err)
+		WriteError(res, http.StatusInternalServerError, err)
 		return
 	}
 	data := make(map[string]interface{})

--- a/system.go
+++ b/system.go
@@ -46,7 +46,7 @@ func SystemInfo(res http.ResponseWriter, req *http.Request) {
 	log.Debug("system info")
 	backend, err := iopodman.GetInfo().Call(podman)
 	if err != nil {
-		WriteError(res, err)
+		WriteError(res, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/tests/cli/images-inspect/Dockerfile
+++ b/tests/cli/images-inspect/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/library/ubuntu
+LABEL dipod.is.awesome=yes
+EXPOSE 80
+USER dipod
+STOPSIGNAL SIGKILL
+VOLUME ["/data"]

--- a/tests/cli/images.bats
+++ b/tests/cli/images.bats
@@ -261,3 +261,13 @@ function cleanup {
     [[ "$(jq -cr ".[0].ContainerConfig.Labels" <<< $output)" == '{"dipod.is.awesome":"yes"}' ]]
     [[ "$(jq -cr ".[0].ContainerConfig.ExposedPorts" <<< $output)" == '{"80/tcp":{}}' ]]
 }
+
+@test "images: inspect not found" {
+    # Arrange/Act
+    run docker inspect does_not_exist:probably
+    echo $output
+
+    # Assert
+    [[ "$status" -eq 1 ]]
+    [[ "$output" =~ "Error: No such object: does_not_exist:probably" ]]
+}

--- a/tests/cli/images.bats
+++ b/tests/cli/images.bats
@@ -175,7 +175,7 @@ function cleanup {
 
 @test "images: inspect advanced" {
     # Arrange
-    podman pull docker.io/library/ubuntu
+    podman pull docker.io/library/node:carbon-onbuild
 
     # Act
     run docker inspect node:carbon-onbuild


### PR DESCRIPTION
This PR adds support for inspecting user, stop signal, ports, volumes and labels. Resolves #12. Other changes: fix tests, more fine-grained control over errors, use `podman` to pull.
