### PR TITLE
Better handle versioning

### DIFF
--- a/dipod.go
+++ b/dipod.go
@@ -12,8 +12,13 @@ const DockerUnixAddress = "/var/run/docker.sock"
 // PodmanUnixAddress is the default address of the Podman unix socket.
 const PodmanUnixAddress = "unix:///run/podman/io.podman"
 
-// APIVersion defines Docker Engine API version supported by this proxy.
+// APIVersion defines maximum Docker Engine API version supported by this
+// proxy.
 const APIVersion = "1.40"
+
+// MinAPIVersion defines minimum Docker Engine API version supported by this
+// proxy.
+const MinAPIVersion = "1.12"
 
 // ProxyVersion identified the dipod version.
 const ProxyVersion = "0.0.1"

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/api/server"
+	"github.com/docker/docker/api/server/middleware"
 	"github.com/docker/docker/api/server/router/build"
 	"github.com/docker/docker/api/server/router/image"
 	"github.com/docker/docker/api/server/router/system"
@@ -46,6 +47,11 @@ func Serve() {
 	// system
 	sys := &systemBackend{}
 	server.InitRouter(system.NewRouter(sys, sys, nil, &features))
+
+	// middleware
+	server.UseMiddleware(
+		middleware.NewVersionMiddleware(ProxyVersion, APIVersion, MinAPIVersion),
+	)
 
 	wait := make(chan error)
 	go server.Wait(wait)

--- a/system.go
+++ b/system.go
@@ -93,7 +93,7 @@ func (*systemBackend) SystemVersion() types.Version {
 		GitCommit:     "",
 		GoVersion:     runtime.Version(),
 		KernelVersion: "n/a",
-		MinAPIVersion: APIVersion,
+		MinAPIVersion: MinAPIVersion,
 		Os:            runtime.GOOS,
 		Version:       ProxyVersion + "-dipod",
 	}

--- a/tests/cli/system.bats
+++ b/tests/cli/system.bats
@@ -8,7 +8,7 @@
     # Assert
     [[ "$(jq -r ".Version" <<< $output)" =~ dipod$ ]]
     [[ "$(jq -r ".ApiVersion" <<< $output)" == "1.40" ]]
-    [[ "$(jq -r ".MinAPIVersion" <<< $output)" == "1.40" ]]
+    [[ "$(jq -r ".MinAPIVersion" <<< $output)" == "1.12" ]]
     [[ "$(jq -r ".Os" <<< $output)" == "linux" ]]
     [[ "$(jq -r ".Arch" <<< $output)" == "amd64" ]]
 
@@ -16,7 +16,7 @@
     [[ "$(jq -r ".Name" <<< $component)" == "Engine" ]]
     [[ "$(jq -r ".Version" <<< $component)" =~ dipod$ ]]
     [[ "$(jq -r ".Details.ApiVersion" <<< $component)" == "1.40" ]]
-    [[ "$(jq -r ".Details.MinAPIVersion" <<< $component)" == "1.40" ]]
+    [[ "$(jq -r ".Details.MinAPIVersion" <<< $component)" == "1.12" ]]
     [[ "$(jq -r ".Details.Os" <<< $component)" == "linux" ]]
     [[ "$(jq -r ".Details.Arch" <<< $component)" == "amd64" ]]
 }


### PR DESCRIPTION
# Overview
Use Docker versioning middleware, which enables us to declare minimum supported and default API versions. This enables client to negotiate a proper API version instead of falling back to `v1.24`.

# Testing
- Smoke tests pass